### PR TITLE
[fix] Create CONTRIBUTING.md and fix documentation accordingly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing to Quiz Genius
+
+Thank you for your interest in contributing to **Quiz Genius**! We welcome all types of contributions, whether it's bug reports, feature requests, or code enhancements. Please follow the guidelines below to help make the process as smooth as possible.
+
+## How to Contribute
+
+### Reporting Bugs and Requesting Features
+
+If you encounter any issues or have ideas to enhance the app, please [open an issue](https://github.com/yagnik2411/Quiz-Genius/issues/new) on GitHub. When reporting bugs, provide:
+
+- A clear and concise description of the issue.
+- Steps to reproduce the issue.
+- Any relevant logs, screenshots, or examples.
+  
+For feature requests, explain the idea and why you think it would be beneficial.
+
+### Code Contributions
+
+We encourage contributions that help improve the app’s functionality, fix bugs, or enhance the user experience. To submit code changes, please follow these steps:
+
+1. **Fork the repository**: Create a personal copy of the repository on GitHub.
+2. **Clone the repository**: Download the forked repository to your machine by running:
+   ```bash
+   git clone https://github.com/yourusername/Quiz-Genius.git
+   ```
+
+> [!NOTE]
+> Note that you should change the text `yourusername` to your actual username on Github
+4. **Create a new branch**: 
+   ```bash
+   git checkout -b your-branch-name
+   ```
+5. **Make your changes**: Implement your feature, bug fix, or improvement. Please ensure your code follows the [Flutter style guide](https://docs.flutter.dev/tools/formatting).
+6. **Test thoroughly**: Verify your changes locally to ensure they work as intended.
+7. **Commit your changes**: Use clear and meaningful commit messages:
+   ```bash
+   git commit -m "Description of your changes"
+   ```
+8. **Push your changes**: 
+   ```bash
+   git push origin your-branch-name
+   ```
+9. **Submit a pull request**: Open a pull request from your branch to the `main` branch of the original repository. Provide a detailed description of your changes.
+
+## Code Review
+
+Your pull request will go through a review process where maintainers may ask for further changes or clarifications. Be sure to respond to feedback and update your pull request accordingly.
+
+## Style Guidelines
+
+Please ensure that all contributions follow the [Flutter style guide](https://docs.flutter.dev/tools/formatting). Consistency in code style helps maintain the quality and readability of the project.
+
+---

--- a/README.md
+++ b/README.md
@@ -50,24 +50,26 @@ The questions are pulled from an external API with the following structure:
 ```
 ## Contributing to Quiz Genius
 
-Thank you for considering contributing to OpSo! We welcome contributions from the community to help improve the app and add new features. Below are some guidelines for contributing:
+Thank you for your interest in contributing to **Quiz Genius**! We greatly appreciate community involvement to help enhance the app and introduce new features. Whether you're reporting bugs or submitting code contributions, your input is valuable. For more detailed information on how to contribute, please refer to the [CONTRIBUTING.md](./CONTRIBUTING.md) file. Here are some guidelines to help you get started:
 
-### Bug Reports and Feature Requests
+### Reporting Bugs and Requesting Features
 
-If you encounter any bugs or have ideas for new features, please [open an issue](https://github.com/yourusername/OpSo/issues) on GitHub. Make sure to provide detailed information about the issue or feature request, including steps to reproduce the bug if applicable.
+If you encounter a bug or have a suggestion for a new feature, please [open an issue](https://github.com/yagnik2411/Quiz-Genius/issues/new). Provide as much detail as possible, including clear reproduction steps if it's a bug. This helps us better understand and address the problem or request.
 
 ### Code Contributions
 
-We appreciate any code contributions that enhance the functionality or improve the user experience of Quiz Genius. To contribute code, follow these steps:
+Contributions that improve functionality or user experience are always welcome. Follow these steps to contribute:
 
-1. Fork the repository to your GitHub account.
-2. Clone your forked repository to your local machine.
-3. Create a new branch for your feature or bug fix: `git checkout -b feature-name`.
-4. Make your changes and ensure that the code follows the [Flutter style guide](https://flutter.dev/docs/development/tools/formatting).
-5. Test your changes locally to ensure they work as expected.
-6. Commit your changes with descriptive commit messages: `git commit -m "Add feature XYZ"`.
-7. Push your changes to your forked repository: `git push origin feature-name`.
-8. Create a pull request against the `main` branch of the original repository.
+1. **Fork** this repository to your GitHub account.
+2. **Clone** your forked repository locally.
+3. **Create a new branch** for your changes: `git checkout -b your-branch-name`.
+4. Implement your changes, ensuring they adhere to the [Flutter style guide](https://docs.flutter.dev/guides/language/effective-dart).
+5. **Test** your changes thoroughly to verify everything works correctly.
+6. Commit your work with a detailed message: `git commit -m "Description of changes"`.
+7. **Push** your branch to your GitHub fork: `git push origin your-branch-name`.
+8. Submit a **pull request** to the main repository's `main` branch, describing the purpose and scope of your changes.
+
+We look forward to your contributions!
 
 ## Getting Started
 


### PR DESCRIPTION
## Description

As previously mentioned in issue #47, this PR creates a **CONTRIBUTING.md** file to be more aligned with the community guidelines, link to the file in the documentation as well as changing an additional error in the documentation that I found during editing, the link to **open an issue** is now changed from the [invalid hyperlink](https://github.com/yourusername/OpSo/issues) to the [working hyperlink](https://github.com/yagnik2411/Quiz-Genius/issues/new).

> [!NOTE]
> Note that the invalid hyperlink links to **Another Project** and it's not even working correctly `https://github.com/yourusername/OpSo/issues`

Please add the `gssoc-ext` and `hacktoberfest-accepted` labels, I strongly suggest that you change the level of the contribution since I've found additional errors than the ones I've mentioned at first.